### PR TITLE
Place on the correct namespace location

### DIFF
--- a/can-view-callbacks.js
+++ b/can-view-callbacks.js
@@ -103,4 +103,4 @@ var callbacks = {
 };
 
 namespace.view = namespace.view || {};
-module.exports = namespace.view.callback = callbacks;
+module.exports = namespace.view.callbacks = callbacks;

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -1,5 +1,6 @@
 var QUnit = require('steal-qunit');
 var callbacks = require('can-view-callbacks');
+var can = require("can-util/namespace");
 
 QUnit.module('can-view-callbacks');
 
@@ -9,4 +10,8 @@ QUnit.test('Initialized the plugin', function(){
   };
   callbacks.attr(/something-\w+/, handler);
   equal(callbacks.attr("something-else"), handler);
+});
+
+QUnit.test("Placed as view.callbacks on the can namespace", function(){
+	equal(callbacks, can.view.callbacks, "Namespace value as can.view.callbacks");
 });


### PR DESCRIPTION
This fixes it so that on the can namespace callbacks is
`can.view.callbacks` as it was in 2.x.

Closes #3
