### PR TITLE
Adds 3rd argument to callbacks.attr

### DIFF
--- a/docs/attr.md
+++ b/docs/attr.md
@@ -40,7 +40,29 @@ canViewCallbacks.attr("show-when", function(el, attrData){
 that matches attribute names. Examples: `"my-fill"` or `/my-\w/`.  
 
 @param {function(HTMLElement,can-view-callbacks.attrData)} attrHandler(el, attrData)
-A function that adds custom behavior to `el`.  
+A function that adds custom behavior to `el`.
+
+@signature `callbacks.attr(attributeName, attrHandler(el, attrData), includeSubtemplate)`
+
+Registers the `attrHandler` callback when `attributeName` is found and makes the handler to receive a subtemplate renderer.
+
+```js
+var canViewCallbacks = require("can-view-callbacks");
+
+var handler = function(el, attrData){
+	// render the subtemplate, if you want
+	var frag = attrData.subtemplate({});
+	el.appendChild(frag);
+};
+
+canViewCallbacks.attr("my-tabs", handler, true);
+```
+
+@param {String} attributeName a lower-case attribute name. No regular expressions are allowed in this signature.
+
+@param {function(HTMLElement, can-view-callbacks.attrData)} attrHandler(el, attrData) A function that adds custom behavior to `el`.
+
+@param {Boolean} [includeSubtemplate=false] A boolean that when true provides a `subtemplate` renderer function as a property on [can-view-callbacks.attrData].
 
 @body
 

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -27,3 +27,14 @@ QUnit.test("Show warning if in tag name a hyphen is missed", function () {
 	};
 	callbacks.tag(tagName, function(){});
 });
+
+QUnit.test("includeSubtemplate third attribute adds attribute to the handler", function(){
+	var attrCallback = function(el, attrData){
+		
+	};
+
+	callbacks.attr("foo-bar", attrCallback, true);
+
+	equal(attrCallback.includeSubtemplate, true, "marked as needing the subtemplate");
+
+});


### PR DESCRIPTION
This adds a 3rd argument to callbacks.attr as described in
https://github.com/canjs/can-stache/issues/15. This is plumbing needed
to make this feature work, more code is needed in can-stache.
