### PR TITLE
Throwing error when multiple versions of can-view-callbacks are loaded

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,7 @@ end_of_line = LF
 indent_style = tab
 trim_trailing_whitespace = false
 insert_final_newline = true
+
+[{package.json,*.yml}]
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js: node
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+addons:
+  firefox: "latest"

--- a/build.js
+++ b/build.js
@@ -8,7 +8,7 @@ stealTools.export({
 		"+amd": {},
 		"+standalone": {
 			exports: {
-				"can-util/namespace": "can"
+				"can-namespace": "can"
 			}
 		}
 	}

--- a/can-view-callbacks.js
+++ b/can-view-callbacks.js
@@ -3,7 +3,7 @@ var Observation = require('can-observation');
 var dev = require('can-util/js/dev/dev');
 var getGlobal = require('can-util/js/global/global');
 var domMutate = require('can-util/dom/mutate/mutate');
-var namespace = require('can-util/namespace');
+var namespace = require('can-namespace');
 
 var attr = function (attributeName, attrHandler) {
 	if(attrHandler) {
@@ -114,4 +114,9 @@ var callbacks = {
 };
 
 namespace.view = namespace.view || {};
-module.exports = namespace.view.callbacks = callbacks;
+
+if (namespace.view.callbacks) {
+	throw new Error("You can't have two versions of can-view-callbacks, check your dependencies");
+} else {
+	module.exports = namespace.view.callbacks = callbacks;
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "npmAlgorithm": "flat"
   },
   "dependencies": {
+    "can-namespace": "1.0.0",
     "can-observation": "^3.0.1",
     "can-util": "^3.0.1"
   },

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -1,7 +1,8 @@
 var QUnit = require('steal-qunit');
 var callbacks = require('can-view-callbacks');
 var dev = require('can-util/js/dev/dev');
-var can = require("can-util/namespace");
+var can = require('can-namespace');
+var clone = require('steal-clone')
 
 QUnit.module('can-view-callbacks');
 
@@ -45,4 +46,24 @@ QUnit.test("remove a tag by passing null as second argument", function() {
 
 	equal(callbacks.tag(tagName), handler, 'passing no second argument should get handler');
 	notEqual(callbacks.tag(tagName, null), handler, 'passing null as second argument should remove handler');
+});
+
+QUnit.test('should throw if can-namespace.view.callbacks is already defined', function() {
+	stop();
+	clone({
+		'can-namespace': {
+			view: {
+				callbacks: {}
+			}
+		}
+	})
+	.import('can-view-callbacks')
+	.then(function() {
+		ok(false, 'should throw');
+		start();
+	})
+	.catch(function(err) {
+		ok(err && err.indexOf('can-view-callbacks') >= 0, 'should throw an error about can-view-callbacks');
+		start();
+	});
 });


### PR DESCRIPTION
Part of https://github.com/canjs/canjs/issues/2747.