### PR TITLE
correctly dependency injecting can-namespace

### DIFF
--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -52,9 +52,12 @@ QUnit.test('should throw if can-namespace.view.callbacks is already defined', fu
 	stop();
 	clone({
 		'can-namespace': {
-			view: {
-				callbacks: {}
-			}
+			default: {
+				view: {
+					callbacks: {}
+				}
+			},
+			__useDefault: true
 		}
 	})
 	.import('can-view-callbacks')


### PR DESCRIPTION
closes https://github.com/canjs/can-view-callbacks/issues/24.