### PR TITLE
updating namespace test to work with Steal 0.16 or Steal 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 addons:
-  firefox: "latest"
+  firefox: "51.0"

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -66,7 +66,8 @@ QUnit.test('should throw if can-namespace.view.callbacks is already defined', fu
 		start();
 	})
 	.catch(function(err) {
-		ok(err && err.message.indexOf('can-view-callbacks') >= 0, 'should throw an error about can-view-callbacks');
+		var errMsg = err && err.message || err;
+		ok(errMsg.indexOf('can-view-callbacks') >= 0, 'should throw an error about can-view-callbacks');
 		start();
 	});
 });


### PR DESCRIPTION
closes https://github.com/canjs/can-view-callbacks/issues/33.