### PR TITLE
Use default noop function for unregistered tags.

### DIFF
--- a/can-view-callbacks.js
+++ b/can-view-callbacks.js
@@ -52,6 +52,7 @@ var attr = function (attributeName, attrHandler) {
 var attributes = {},
 	regExpAttributes = [],
 	automaticCustomElementCharacters = /[-\:]/;
+var defaultCallback = function () {};
 
 var tag = function (tagName, tagHandler) {
 	if(tagHandler) {
@@ -82,7 +83,7 @@ var tag = function (tagName, tagHandler) {
 
 		if(!cb && automaticCustomElementCharacters.test(tagName)) {
 			// empty callback for things that look like special tags
-			cb = function(){};
+			cb = defaultCallback;
 		}
 		return cb;
 	}
@@ -94,6 +95,7 @@ var callbacks = {
 	_tags: tags,
 	_attributes: attributes,
 	_regExpAttributes: regExpAttributes,
+	defaultCallback: defaultCallback,
 	tag: tag,
 	attr: attr,
 	// handles calling back a tag callback

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -106,4 +106,12 @@ if (System.env.indexOf('production') < 0) {
 		// callback attr provided
 		callbacks.attr(attrMatch, function(){});
 	});
+
+	QUnit.test("tag method should return default callback when valid tag but not registered", function () {
+		equal(callbacks.tag('not-exist'), callbacks.defaultCallback, "used default noop function")
+	});
+
+	QUnit.test("tag method should return undefined when invalid tag and not registered", function () {
+		notOk(callbacks.tag('notexist'), "used default noop function")
+	});
 }


### PR DESCRIPTION
When a tag handler is requested but the tag does not exist, an anonymous noop function is returned. It should instead return the new default noop function. This is needed for consuming packages to check if the requested tag does not exist.

- Updated main to export a default noop
- Updated main to return default noop when requested tag does not exist
- Updated tests to check use cases

Needed for this issue: https://github.com/canjs/can-view-import/issues/2