### PR TITLE
Only automount if the can-automount flag is not set to false

### DIFF
--- a/can-view-callbacks.js
+++ b/can-view-callbacks.js
@@ -43,6 +43,7 @@ var renderNodeAndChildren = function(node) {
 };
 
 var mutationObserverEnabled = false;
+var globalMutationObserver;
 var enableMutationObserver = function() {
 	if (mutationObserverEnabled) {
 		return;
@@ -67,8 +68,11 @@ var enableMutationObserver = function() {
 
 	var MutationObserver = globals.getKeyValue("MutationObserver");
 	if(MutationObserver) {
-		var obs = new MutationObserver(mutationHandler);
-		obs.observe(getGlobal().document.documentElement, { childList: true, subtree: true });
+		globalMutationObserver = new MutationObserver(mutationHandler);
+		globalMutationObserver.observe(getGlobal().document.documentElement, {
+			childList: true,
+			subtree: true
+		});
 
 		mutationObserverEnabled = true;
 	}
@@ -188,6 +192,8 @@ var tag = function (tagName, tagHandler) {
 				enableMutationObserver();
 				renderTagsInDocument(tagName);
 			}
+		} else if(mutationObserverEnabled) {
+			globalMutationObserver.disconnect();
 		}
 	} else {
 		var cb;

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -409,3 +409,24 @@ QUnit.test("Works in environments without MutationObserver", function() {
 		QUnit.start();
 	});
 });
+
+QUnit.test("automounting doesn't happen if the data-can-automount flag is set to false", function() {
+	var fixture = document.getElementById('qunit-fixture');
+	document.documentElement.dataset.canAutomount = "false";
+
+	callbacks.tag("automount-false", function(el) {
+		var textNode = document.createTextNode("This is the automount-false");
+		el.appendChild(textNode);
+		ok(false, "this shouldn't have been mounted :(");
+	});
+
+	var theAutomaticallyHandledTag = document.createElement("automount-false");
+	fixture.appendChild(theAutomaticallyHandledTag);
+
+	QUnit.stop();
+	afterMutation(function() {
+		QUnit.equal(theAutomaticallyHandledTag.innerHTML, "");
+		delete document.documentElement.dataset.canAutomount;
+		QUnit.start();
+	});
+});

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -427,6 +427,7 @@ QUnit.test("automounting doesn't happen if the data-can-automount flag is set to
 	afterMutation(function() {
 		QUnit.equal(theAutomaticallyHandledTag.innerHTML, "");
 		delete document.documentElement.dataset.canAutomount;
+		fixture.innerHTML = "";
 		QUnit.start();
 	});
 });


### PR DESCRIPTION
This updates the automount behavior so that we only automount when then
HTML tag doesn't contain a `data-can-automount="false"` flag. This flag
will be set by done-autorender, which is a case where we don't want
automounting to occur.

Part of: https://github.com/donejs/donejs/issues/1066