### PR TITLE
Fix issue with edge for double insert

### DIFF
--- a/can-view-callbacks.js
+++ b/can-view-callbacks.js
@@ -34,16 +34,20 @@ var automountEnabled = function(){
 
 var renderedElements = new WeakMap();
 
-var renderNodeAndChildren = function(node) {
+var mountElement = function (node) {
 	var tagName = node.tagName && node.tagName.toLowerCase();
 	var tagHandler = tags[tagName];
-	var children;
 
 	// skip elements that already have a viewmodel or elements whose tags don't match a registered tag
 	// or elements that have already been rendered
 	if (tagHandler && !renderedElements.has(node)) {
 		tagHandler(node, {});
 	}
+};
+
+var renderNodeAndChildren = function(node) {
+	var children;
+	mountElement(node);
 
 	if (node.getElementsByTagName) {
 		children = node.getElementsByTagName("*");
@@ -93,7 +97,7 @@ var renderTagsInDocument = function(tagName) {
 	var nodes = getGlobal().document.getElementsByTagName(tagName);
 
 	for (var i=0, node; (node = nodes[i]) !== undefined; i++) {
-		renderNodeAndChildren(node);
+		mountElement(node);
 	}
 };
 

--- a/can-view-callbacks.js
+++ b/can-view-callbacks.js
@@ -269,11 +269,11 @@ var callbacks = {
 
 		// If this was an element like <foo-bar> that doesn't have a component, just render its content
 		if(tagCallback) {
+			res = ObservationRecorder.ignore(tagCallback)(el, tagData);
+			
 			// add the element to the Set of elements that have had their handlers called
 			// this will prevent the handler from being called again when the element is inserted
 			renderedElements.set(el, true);
-
-			res = ObservationRecorder.ignore(tagCallback)(el, tagData);
 		} else {
 			res = scope;
 		}

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -512,23 +512,24 @@ QUnit.test("Prevent throwing when there is no documentElement in tag() #100", fu
 
 QUnit.test("Edge prevent double insert", function () {
 	var fixture = document.getElementById('qunit-fixture');
-
-	var outerEl = document.createElement("edge-double-insert-outer");
-	var innerEl = document.createElement("edge-double-insert-inner");
-
-	outerEl.appendChild(innerEl);
-	fixture.appendChild(outerEl);
+	var innerElCounter = 0, outerElCounter = 0;
 
 	callbacks.tag("edge-double-insert-inner", function(el) {
-		el.innerHTML = "the edge-double-insert-inner element";
+		innerElCounter++;
 	});
 
-	callbacks.tag("edge-double-insert-outer", function() {});
+	fixture.innerHTML = "<edge-double-insert-outer></edge-double-insert-outer>";
+
+	callbacks.tag("edge-double-insert-outer", function(el) {
+		outerElCounter++;
+		el.innerHTML = "<edge-double-insert-inner></edge-double-insert-inner>";
+		callbacks.tagHandler(el.firstChild, "edge-double-insert-inner", {});
+	});
 
 	QUnit.stop();
 	afterMutation(function() {
-		QUnit.equal(innerEl.innerHTML, "the edge-double-insert-inner element");
-		fixture.innerHTML = "";
+		QUnit.equal(innerElCounter, 1, "inner called once");
+		QUnit.equal(outerElCounter, 1, "outer called once");
 		QUnit.start();
 	});
 });

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -509,3 +509,26 @@ QUnit.test("Prevent throwing when there is no documentElement in tag() #100", fu
 	}
 
 });
+
+QUnit.test("Edge prevent double insert", function () {
+	var fixture = document.getElementById('qunit-fixture');
+
+	var outerEl = document.createElement("edge-double-insert-outer");
+	var innerEl = document.createElement("edge-double-insert-inner");
+
+	outerEl.appendChild(innerEl);
+	fixture.appendChild(outerEl);
+
+	callbacks.tag("edge-double-insert-inner", function(el) {
+		el.innerHTML = "the edge-double-insert-inner element";
+	});
+
+	callbacks.tag("edge-double-insert-outer", function() {});
+
+	QUnit.stop();
+	afterMutation(function() {
+		QUnit.equal(innerEl.innerHTML, "the edge-double-insert-inner element");
+		fixture.innerHTML = "";
+		QUnit.start();
+	});
+});


### PR DESCRIPTION
The inner element was being rendered twice, renderTagsInDocument was calling renderNodeAndChildren which was recursively mounting elements, and then mutation observer was adding it again.

Closes: https://github.com/canjs/can-view-callbacks/issues/105