### PR TITLE
Use the registered global document

### DIFF
--- a/can-view-callbacks.js
+++ b/can-view-callbacks.js
@@ -3,6 +3,7 @@ var ObservationRecorder = require('can-observation-recorder');
 
 var dev = require('can-log/dev/dev');
 var getGlobal = require('can-globals/global/global');
+var getDocument = require('can-globals/document/document');
 var domMutate = require('can-dom-mutate/node');
 var namespace = require('can-namespace');
 var nodeLists = require('can-view-nodelist');
@@ -81,7 +82,7 @@ var enableMutationObserver = function() {
 	var MutationObserver = globals.getKeyValue("MutationObserver");
 	if(MutationObserver) {
 		globalMutationObserver = new MutationObserver(mutationHandler);
-		globalMutationObserver.observe(getGlobal().document.documentElement, {
+		globalMutationObserver.observe(getDocument().documentElement, {
 			childList: true,
 			subtree: true
 		});
@@ -91,7 +92,7 @@ var enableMutationObserver = function() {
 };
 
 var renderTagsInDocument = function(tagName) {
-	var nodes = getGlobal().document.getElementsByTagName(tagName);
+	var nodes = getDocument().getElementsByTagName(tagName);
 
 	for (var i=0, node; (node = nodes[i]) !== undefined; i++) {
 		mountElement(node);
@@ -270,7 +271,7 @@ var callbacks = {
 		// If this was an element like <foo-bar> that doesn't have a component, just render its content
 		if(tagCallback) {
 			res = ObservationRecorder.ignore(tagCallback)(el, tagData);
-			
+
 			// add the element to the Set of elements that have had their handlers called
 			// this will prevent the handler from being called again when the element is inserted
 			renderedElements.set(el, true);
@@ -282,7 +283,7 @@ var callbacks = {
 		if (process.env.NODE_ENV !== 'production') {
 			if (!tagCallback) {
 				var GLOBAL = getGlobal();
-				var ceConstructor = GLOBAL.document.createElement(tagName).constructor;
+				var ceConstructor = getDocument().createElement(tagName).constructor;
 				// If not registered as a custom element, the browser will use default constructors
 				if (ceConstructor === GLOBAL.HTMLElement || ceConstructor === GLOBAL.HTMLUnknownElement) {
 					dev.warn('can-view-callbacks: No custom element found for ' + tagName);

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -510,6 +510,30 @@ QUnit.test("Prevent throwing when there is no documentElement in tag() #100", fu
 
 });
 
+QUnit.test("Renders to the correct document", function() {
+	var realGlobal = globals.getKeyValue("global");
+	var newGlobal = {};
+	globals.setKeyValue("global", newGlobal);
+	globals.deleteKeyValue("customElements");
+
+	var newDoc = document.implementation.createHTMLDocument("Testing");
+	newDoc.body.appendChild(newDoc.createElement("tag-in-this-doc"));
+	globals.setKeyValue("document", newDoc);
+
+	try {
+		callbacks.tag("tag-in-this-doc", function(el) {
+			var txt = newDoc.createTextNode("works");
+			el.appendChild(txt);
+		});
+	} catch(e) {}
+	finally {
+		QUnit.equal(newDoc.body.firstChild.firstChild.nodeValue, "works", "Updated the correct document");
+
+		globals.setKeyValue("global", realGlobal);
+		globals.setKeyValue("document", realGlobal.document);
+	}
+});
+
 QUnit.test("Edge prevent double insert", function () {
 	var fixture = document.getElementById('qunit-fixture');
 	var innerElCounter = 0, outerElCounter = 0;


### PR DESCRIPTION
This makes it so that we always use the registered global document from
can-globals, and not the registered `global` and expecting it to have a
document property.