### PR TITLE
adding support for initializing a custom element using a Symbol

### DIFF
--- a/can-view-callbacks.js
+++ b/can-view-callbacks.js
@@ -14,6 +14,7 @@ var canSymbol = require('can-symbol');
 var canReflect = require('can-reflect');
 
 var callbackMapSymbol = canSymbol.for('can.callbackMap');
+var initializeViewModelSymbol = canSymbol.for('can.initializeViewModel');
 
 //!steal-remove-start
 if (process.env.NODE_ENV !== 'production') {
@@ -245,7 +246,7 @@ var callbacks = {
 
 		var scope = tagData.scope,
 			helperTagCallback = scope && scope.templateContext.tags.get(tagName),
-			tagCallback = helperTagCallback || tags[tagName],
+			tagCallback = helperTagCallback || tags[tagName] || el[initializeViewModelSymbol],
 			res;
 
 		// If this was an element like <foo-bar> that doesn't have a component, just render its content

--- a/can-view-callbacks.js
+++ b/can-view-callbacks.js
@@ -14,7 +14,7 @@ var canSymbol = require('can-symbol');
 var canReflect = require('can-reflect');
 
 var callbackMapSymbol = canSymbol.for('can.callbackMap');
-var initializeViewModelSymbol = canSymbol.for('can.initializeViewModel');
+var initializeSymbol = canSymbol.for('can.initialize');
 
 //!steal-remove-start
 if (process.env.NODE_ENV !== 'production') {
@@ -246,7 +246,7 @@ var callbacks = {
 
 		var scope = tagData.scope,
 			helperTagCallback = scope && scope.templateContext.tags.get(tagName),
-			tagCallback = helperTagCallback || tags[tagName] || el[initializeViewModelSymbol],
+			tagCallback = helperTagCallback || tags[tagName] || el[initializeSymbol],
 			res;
 
 		// If this was an element like <foo-bar> that doesn't have a component, just render its content

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -10,6 +10,8 @@ var domMutate = require('can-dom-mutate');
 var domMutateNode = require('can-dom-mutate/node');
 var globals = require('can-globals');
 
+var supportsCustomElements = 'customElements' in window;
+
 function afterMutation(cb) {
 	var doc = globals.getKeyValue('document');
 	var div = doc.createElement("div");
@@ -595,3 +597,21 @@ QUnit.test("MutationObserver mounts each element once in browsers that do not su
 	var outer = doc.createElement("mount-once-outer");
 	fixture.appendChild(outer);
 });
+
+if (supportsCustomElements) {
+	QUnit.test("calls initializeViewModel Symbol on custom element", function(assert) {
+		var tagName = "initialize-viewmodel-el";
+		var tagData = {};
+		var el;
+
+		function El() {}
+		El.prototype[canSymbol.for("can.initializeViewModel")] = function(elBeingInitialized, tagDataPassedToInitialize) {
+			assert.equal(elBeingInitialized, el, "el is passed correctly");
+			assert.equal(tagDataPassedToInitialize, tagData, "tagData is passed correctly");
+		};
+		customElements.define(tagName, El);
+
+		el = new El();
+		callbacks.tagHandler(el, tagName, tagData);
+	});
+}

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -599,13 +599,13 @@ QUnit.test("MutationObserver mounts each element once in browsers that do not su
 });
 
 if (supportsCustomElements) {
-	QUnit.test("calls initializeViewModel Symbol on custom element", function(assert) {
+	QUnit.test("calls can.initialize Symbol on custom element", function(assert) {
 		var tagName = "initialize-viewmodel-el";
 		var tagData = {};
 		var el;
 
 		function El() {}
-		El.prototype[canSymbol.for("can.initializeViewModel")] = function(elBeingInitialized, tagDataPassedToInitialize) {
+		El.prototype[canSymbol.for("can.initialize")] = function(elBeingInitialized, tagDataPassedToInitialize) {
 			assert.equal(elBeingInitialized, el, "el is passed correctly");
 			assert.equal(tagDataPassedToInitialize, tagData, "tagData is passed correctly");
 		};


### PR DESCRIPTION
closes https://github.com/canjs/can-view-callbacks/issues/116.

This makes it possible to add a Symbol to a Custom Element (`can.initializeViewModel`) so that the element can be initialized with data from bindings when rendered by can-stache.