### PR TITLE
Rewrite test for verifying how many times a tag is mounted

### DIFF
--- a/can-view-callbacks.js
+++ b/can-view-callbacks.js
@@ -152,8 +152,6 @@ var defaultCallback = function () {};
 
 var tag = function (tagName, tagHandler) {
 	if(tagHandler) {
-		var GLOBAL = getGlobal();
-
 		var validCustomElementName = automaticCustomElementCharacters.test(tagName),
 			tagExists = typeof tags[tagName.toLowerCase()] !== 'undefined',
 			customElementExists;

--- a/can-view-callbacks.js
+++ b/can-view-callbacks.js
@@ -170,12 +170,6 @@ var tag = function (tagName, tagHandler) {
 		}
 		//!steal-remove-end
 
-		// if we have html5shiv ... re-generate
-		if (GLOBAL.html5) {
-			GLOBAL.html5.elements += " " + tagName;
-			GLOBAL.html5.shivDocument();
-		}
-
 		tags[tagName.toLowerCase()] = tagHandler;
 
 		if(automountEnabled()) {

--- a/test/callbacks-test.js
+++ b/test/callbacks-test.js
@@ -567,21 +567,14 @@ QUnit.test("MutationObserver mounts each element once in browsers that do not su
 	var fixture = doc.getElementById('qunit-fixture');
 	var innerElCounter = 0, outerElCounter = 0;
 
-	callbacks.tag("mount-once-inner", function(el) {});
+	callbacks.tag("mount-once-inner", function(el) {
+		innerElCounter++;
+	});
 	callbacks.tag("mount-once-outer", function(el) {
+		outerElCounter++;
 		var inner = doc.createElement("mount-once-inner");
 		el.appendChild(inner);
 	});
-
-	var origTagHandler = callbacks.tagHandler;
-	callbacks.tagHandler = function(el, tagName) {
-		if (tagName === "mount-once-inner") {
-			innerElCounter++;
-		} else if (tagName === "mount-once-outer") {
-			outerElCounter++;
-		}
-		origTagHandler.apply(this, arguments);
-	};
 
 	var done = assert.async();
 	afterMutation(function() {
@@ -590,7 +583,6 @@ QUnit.test("MutationObserver mounts each element once in browsers that do not su
 		globals.setKeyValue("customElements", function(){
 			return oldCE;
 		});
-		callbacks.tagHandler = origTagHandler;
 		done();
 	});
 


### PR DESCRIPTION
This updates the test because the way we ensure that tag is only
rendered once has changed. This is handled in tagHandler, so we can just
do the check in the individual tag callbacks.